### PR TITLE
feat: writer with spark engine and nebula sink

### DIFF
--- a/examples/spark_engine.ipynb
+++ b/examples/spark_engine.ipynb
@@ -50,6 +50,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\r",
       "[Stage 0:>                                                          (0 + 1) / 1]"
      ]
     },
@@ -71,6 +72,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "\r",
       "                                                                                \r"
      ]
     }
@@ -98,13 +100,6 @@
    "id": "90069aaf",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -134,20 +129,7 @@
       "|player121|\n",
       "+---------+\n",
       "only showing top 20 rows\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\n",
       "+-----+------+-----------+----------+\n",
       "|_rank|degree|     _srcId|    _dstId|\n",
       "+-----+------+-----------+----------+\n",
@@ -180,7 +162,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "                                                                                \r"
+      "23/03/01 13:17:34 WARN BlockManager: Block rdd_75_2 already exists on this machine; not re-adding it\n",
+      "23/03/01 13:17:34 WARN BlockManager: Block rdd_75_3 already exists on this machine; not re-adding it\n",
+      "23/03/01 13:17:34 WARN BlockManager: Block rdd_75_1 already exists on this machine; not re-adding it\n"
      ]
     }
    ],
@@ -209,11 +193,11 @@
       "+---------+-------------------+\n",
       "|      _id|           pagerank|\n",
       "+---------+-------------------+\n",
-      "|player133|0.18601069183310506|\n",
-      "|player126|0.18601069183310506|\n",
-      "|player130| 1.2400712788873671|\n",
-      "|player108|0.18601069183310506|\n",
-      "|player102| 1.6602373739502538|\n",
+      "|player133|0.18601069183310504|\n",
+      "|player126|0.18601069183310504|\n",
+      "|player130|  1.240071278887367|\n",
+      "|player108|0.18601069183310504|\n",
+      "|player102| 1.6602373739502536|\n",
       "+---------+-------------------+\n",
       "only showing top 5 rows\n",
       "\n"
@@ -388,10 +372,210 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3d088006",
+   "metadata": {},
+   "source": [
+    "### Write back algo result to NebulaGraph\n",
+    "\n",
+    "Assume that we have a Spark DataFrame `df_result` computed with `df.algo.label_propagation()` with the following schema:\n",
+    "\n",
+    "```python\n",
+    "df_result.printSchema()\n",
+    "# result:\n",
+    "root\n",
+    " |-- _id: string (nullable = false)\n",
+    " |-- lpa: string (nullable = false)\n",
+    "```\n",
+    "\n",
+    "There are two columns, `_id` is the vid, and `lpa` is the label propagation detected cluster id, let's write them back to tag: label_propagation(cluster_id). So we create a TAG `label_propagation` in NebulaGraph on same space with the following schema:\n",
+    "\n",
+    "```ngql\n",
+    "CREATE TAG IF NOT EXISTS label_propagation (\n",
+    "    cluster_id string NOT NULL\n",
+    ");\n",
+    "```\n",
+    "\n",
+    "Then, we could write the label propagation result to NebulaGraph, map the column `lpa` to `cluster_id`:\n",
+    "```python\n",
+    "properties = {\n",
+    "    \"lpa\": \"cluster_id\"\n",
+    "}\n",
+    "```\n",
+    "And pass it to NebulaWriter in `spark` engine and `nebulagraph_vertex` sink"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6b43261f",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---------+\n",
+      "|       id|\n",
+      "+---------+\n",
+      "|player129|\n",
+      "|player120|\n",
+      "|player148|\n",
+      "|player103|\n",
+      "|player128|\n",
+      "|player108|\n",
+      "|player117|\n",
+      "|player150|\n",
+      "|player125|\n",
+      "|player137|\n",
+      "|player139|\n",
+      "|player140|\n",
+      "|player134|\n",
+      "|player149|\n",
+      "|player102|\n",
+      "|player135|\n",
+      "|player147|\n",
+      "|player121|\n",
+      "|player143|\n",
+      "|player101|\n",
+      "+---------+\n",
+      "only showing top 20 rows\n",
+      "\n",
+      "+-----+------+----------+-----------+\n",
+      "|_rank|degree|    _srcId|     _dstId|\n",
+      "+-----+------+----------+-----------+\n",
+      "|    0|    70|         3|17179869184|\n",
+      "|    0|    80|         5|25769803785|\n",
+      "|    0|    80|         5|17179869189|\n",
+      "|    0|    80|         1|25769803784|\n",
+      "|    0|    90|         4|25769803778|\n",
+      "|    0|    90|         4|17179869187|\n",
+      "|    0|    90|         4|          0|\n",
+      "|    0|    90|         0|25769803778|\n",
+      "|    0|    90|         0|17179869187|\n",
+      "|    0|    90|         0|          4|\n",
+      "|    0|    80|         2|34359738370|\n",
+      "|    0|    90|         2|25769803781|\n",
+      "|    0|    85|         2| 8589934594|\n",
+      "|    0|    90|8589934593|25769803785|\n",
+      "|    0|    -1|8589934597|17179869187|\n",
+      "|    0|    10|8589934594|          0|\n",
+      "|    0|    80|8589934594|25769803781|\n",
+      "|    0|    80|8589934594|          2|\n",
+      "|    0|    99|8589934595|25769803776|\n",
+      "|    0|    90|8589934596|34359738368|\n",
+      "+-----+------+----------+-----------+\n",
+      "only showing top 20 rows\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "23/03/01 13:18:01 WARN CacheManager: Asked to cache already cached data.\n",
+      "23/03/01 13:18:01 WARN CacheManager: Asked to cache already cached data.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Run label Propagation Algorithm\n",
+    "df_result = df.algo.label_propagation()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a6e011db",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root\n",
+      " |-- _id: string (nullable = false)\n",
+      " |-- lpa: string (nullable = false)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# check the result schema\n",
+    "df_result.printSchema()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "c5bbf9e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ngdi import NebulaWriter\n",
+    "from ngdi.config import NebulaGraphConfig\n",
+    "\n",
+    "config = NebulaGraphConfig()\n",
+    "writer = NebulaWriter(data=df_result, sink=\"nebulagraph_vertex\", config=config, engine=\"spark\")\n",
+    "\n",
+    "# map column louvain into property cluster_id\n",
+    "properties = {\n",
+    "    \"lpa\": \"cluster_id\"\n",
+    "}\n",
+    "\n",
+    "writer.set_options(\n",
+    "    tag=\"label_propagation\",\n",
+    "    vid_field=\"_id\",\n",
+    "    properties=properties,\n",
+    "    batch_size=256,\n",
+    "    write_mode=\"insert\",\n",
+    ")\n",
+    "# write back to NebulaGraph\n",
+    "writer.write()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9da30271",
+   "metadata": {},
+   "source": [
+    "Then we could query the result in NebulaGraph:\n",
+    "\n",
+    "```cypher\n",
+    "MATCH (v:label_propagation)\n",
+    "RETURN id(v), v.label_propagation.cluster_id LIMIT 10;\n",
+    "```\n",
+    "Result:\n",
+    "\n",
+    "```cypher\n",
+    "(root@nebula) [basketballplayer]> \"\"\"\n",
+    "                               -> MATCH (v:label_propagation)\n",
+    "                               -> RETURN id(v), v.label_propagation.cluster_id LIMIT 10;\n",
+    "                               -> \"\"\"\n",
+    "+-------------+--------------------------------+\n",
+    "| id(v)       | v.label_propagation.cluster_id |\n",
+    "+-------------+--------------------------------+\n",
+    "| \"player103\" | \"player101\"                    |\n",
+    "| \"player113\" | \"player129\"                    |\n",
+    "| \"player121\" | \"player129\"                    |\n",
+    "| \"player128\" | \"player129\"                    |\n",
+    "| \"player130\" | \"player130\"                    |\n",
+    "| \"player136\" | \"player136\"                    |\n",
+    "| \"player127\" | \"player137\"                    |\n",
+    "| \"player135\" | \"player101\"                    |\n",
+    "| \"player147\" | \"player148\"                    |\n",
+    "| \"player148\" | \"player148\"                    |\n",
+    "+-------------+--------------------------------+\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5bcb02e2",
    "metadata": {},
    "source": [
-    "## Other algorithm examples"
+    "## How to run other algorithm examples"
    ]
   },
   {
@@ -437,4 +621,3 @@
  "nbformat": 4,
  "nbformat_minor": 5
 }
-

--- a/ngdi/engines.py
+++ b/ngdi/engines.py
@@ -58,6 +58,8 @@ class SparkEngine(BaseEngine):
         self.prepare()
         self.nebula_spark_ds = NEBULA_SPARK_CONNECTOR_DATASOURCE
 
+        # TBD: ping NebulaGraph Meta and Storage Server, fail and guide user to check config
+
     def __str__(self):
         return f"SparkEngine: {self.spark}"
 
@@ -87,12 +89,14 @@ class SparkEngine(BaseEngine):
 
         from py4j.java_gateway import java_import
 
+        # scala:
         # import "com.vesoft.nebula.algorithm.config.SparkConfig"
         java_import(self.spark._jvm, "com.vesoft.nebula.algorithm.config.SparkConfig")
         return java_import
 
     def import_scala_class(self, class_name):
         """
+        For example:
         scala:
             import "com.vesoft.nebula.algorithm.lib.PageRankAlgo"
         python:
@@ -107,7 +111,7 @@ class SparkEngine(BaseEngine):
         self.import_scala_class(f"{NEBULA_ALGO_LIB}.{class_name}")
 
 
-class NebulaEngine(object):
+class NebulaEngine(BaseEngine):
     def __init__(self, config=None):
         self.type = "nebula"
         self.config = config

--- a/ngdi/nebula_algo.py
+++ b/ngdi/nebula_algo.py
@@ -130,7 +130,7 @@ class NebulaDataFrameAlgorithm:
         return result
 
     @algo
-    def louvain(self, max_iter: int = 10, internalIter: int = 10, tol: float = 0.0001):
+    def louvain(self, max_iter: int = 20, internalIter: int = 10, tol: float = 0.5):
         engine, spark, jspark, encode_vertex_id = self.get_spark_engine_context(
             "LouvainConfig", "LouvainAlgo"
         )

--- a/ngdi/nebula_reader.py
+++ b/ngdi/nebula_reader.py
@@ -28,7 +28,9 @@ class NebulaReaderBase(object):
 
 
 class NebulaReader:
-    def __init__(self, engine="spark", config=NebulaGraphConfig(), **kwargs):
+    def __init__(
+        self, engine="spark", config: NebulaGraphConfig = NebulaGraphConfig(), **kwargs
+    ):
         self.engine_type = engine
         if self.engine_type == "spark":
             self.reader = NebulaReaderWithSpark(config, **kwargs)
@@ -126,7 +128,7 @@ class NebulaReaderWithSpark(NebulaReaderBase):
             .option("partitionNumber", partition_number)
         )
 
-    def query(self, query=None, **kwargs):
+    def query(self, query: str, **kwargs):
         # Implement the query method specific to Spark engine
         """
         df = spark.read.format(

--- a/ngdi/nebula_writer.py
+++ b/ngdi/nebula_writer.py
@@ -1,11 +1,304 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2023 The NebulaGraph Authors. All rights reserved.
+from __future__ import annotations
+
+from ngdi.config import NebulaGraphConfig
+from ngdi.nebula_data import NebulaDataFrameObject
+
+SPARK_NEBULA_SINKS = ["nebulagraph_vertex", "nebulagraph_edge"]
+SPARK_FILE_SINKS = ["csv", "json", "parquet"]
+SPARK_SERVER_SINKS = []
+SPARK_SINKS = SPARK_NEBULA_SINKS + SPARK_FILE_SINKS + SPARK_SERVER_SINKS
 
 
-class NebulaWriter(object):
+class NebulaWriterBase(object):
     def __init__(self, engine=None, config=None, **kwargs):
-        self.engine = engine
+        self.engine_type = engine
         self.config = config
 
     def write(self, **kwargs):
         raise NotImplementedError
+
+    def options(self, **kwargs):
+        raise NotImplementedError
+
+    def show_options(self, **kwargs):
+        raise NotImplementedError
+
+
+class NebulaWriter:
+    def __init__(
+        self,
+        data,
+        sink: str = "nebulagraph_vertex",
+        config: NebulaGraphConfig = NebulaGraphConfig(),
+        engine: str = "spark",
+        **kwargs,
+    ):
+        self.engine_type = engine
+        if self.engine_type == "spark":
+            self.writer = NebulaWriterWithSpark(data, sink, config, **kwargs)
+        elif self.engine_type == "nebula":
+            self.writer = NebulaWriterWithGraph(data, sink, config, **kwargs)
+        else:
+            raise NotImplementedError
+
+    def __getattr__(self, name):
+        return getattr(self.writer, name)
+
+
+class NebulaWriterWithGraph(NebulaWriterBase):
+    def __init__(self, data, sink: str, config: NebulaGraphConfig, **kwargs):
+        super().__init__("nebula", config, **kwargs)
+        from ngdi.engines import NebulaEngine
+
+        self.engine = NebulaEngine(config)
+        self.raw_df = None
+        self.df = None
+
+
+class NebulaWriterWithSpark(NebulaWriterBase):
+    def __init__(self, data, sink: str, config: NebulaGraphConfig, **kwargs):
+        super().__init__("spark", config, **kwargs)
+        from ngdi.engines import SparkEngine
+
+        self.engine = SparkEngine(config)
+        self.raw_df = None
+        self.raw_df_writer = None
+        self.df = None
+        self.jdf = None
+        self.sink = sink
+        self._options = {}
+
+        from py4j.java_gateway import JavaObject
+
+        if isinstance(data, NebulaDataFrameObject):
+            self.df = data
+            self.raw_df = data.data
+        elif isinstance(data, JavaObject):
+            self.jdf = data
+        else:
+            raise NotImplementedError
+
+    def _convert_java_object_to_spark_df(self, jdf, column_map: dict = {}):
+        """
+        Convert JavaObject to Spark DataFrame, with column name mapping
+        ref: https://stackoverflow.com/questions/36023860/how-to-use-a-scala-class-inside-pyspark
+        """
+        from pyspark.sql import DataFrame
+
+        spark = self.engine.spark
+        jdf = jdf.toDF()
+        for k, v in column_map.items():
+            jdf = jdf.withColumnRenamed(k, v)
+        return DataFrame(jdf, spark)
+
+    def _get_raw_df_writer_with_nebula(self):
+        datasource_format = self.engine.nebula_spark_ds
+        # hard code as overwrite SaveMode
+        return self.raw_df.write.format(datasource_format).mode("overwrite")
+
+    def _get_raw_df_writer_with_file(self):
+        raise NotImplementedError
+
+    def _get_raw_df_writer_with_server(self):
+        raise NotImplementedError
+
+    def _get_raw_df_writer(self):
+        # validate sink
+        assert self.sink in SPARK_SINKS, (
+            f"Sink should be one of {SPARK_SINKS}, " f"but got {self.sink}",
+        )
+
+        if self.raw_df_writer is None:
+            if self.sink in SPARK_NEBULA_SINKS:
+                self.raw_df_writer = self._get_raw_df_writer_with_nebula()
+            elif self.sink in SPARK_FILE_SINKS:
+                self.raw_df_writer = self._get_raw_df_writer_with_file()
+            elif self.sink in SPARK_SERVER_SINKS:
+                self.raw_df_writer = self._get_raw_df_writer_with_server()
+            else:
+                raise NotImplementedError
+        return self.raw_df_writer
+
+    def _set_options_with_nebula(self, **kwargs):
+        writer = self.raw_df_writer
+        # type setting
+        type = kwargs.get("type", "vertex")
+        assert type in [
+            "vertex",
+            "edge",
+        ], f"type should be vertex or edge, but got {type}"
+        writer.option("type", type)
+        self._options["type"] = type
+
+        # space setting, set only when it's specified, else inherit from NebulaGraphConfig
+        space = kwargs.get("space", self.config.space)
+        assert space is not None, "space should be specified"
+        writer.option("spaceName", space)
+        self._options["spaceName"] = space
+
+        # label setting, for vertex case, it's tag, for edge case, it's edge type
+        label = (
+            kwargs.get("tag", None)
+            if type == "vertex"
+            else kwargs.get("edge_type", None)
+        )
+        assert (
+            label is not None
+        ), "tag(for vertex) or edge_type(for edge) should be specified"
+        writer.option("label", label)
+        self._options["label"] = label
+
+        # writeMode setting, by default, it's insert, accept update or delete, too
+        write_mode = kwargs.get("write_mode", "insert")
+        assert write_mode in [
+            "insert",
+            "update",
+            "delete",
+        ], f"write_mode should be insert, update or delete, but got {write_mode}"
+        writer.option("writeMode", write_mode)
+
+        # batch setting, by default, it's 256
+        batch = kwargs.get("batch", 256)
+        assert isinstance(
+            batch, int
+        ), f"batch should be an integer, but got {type(batch)}"
+        writer.option("batch", batch)
+        self._options["batch"] = batch
+
+        # credential from NebulaGraphConfig
+        writer.option("metaAddress", self.config.metad_hosts)
+        writer.option("graphAddress", self.config.graphd_hosts)
+        writer.option("user", self.config.user)
+        self._options["metaAddress"] = self.config.metad_hosts
+        self._options["graphAddress"] = self.config.graphd_hosts
+        self._options["user"] = self.config.user
+        writer.option("password", self.config.password)
+
+        if type == "vertex":
+            # vidPolicy setting, by default, it's empty, accept hash or uuid, too
+            vid_policy = kwargs.get("vid_policy", "")
+            assert vid_policy in [
+                "",
+                "hash",
+                "uuid",
+            ], f"vid_policy should be empty, hash or uuid, but got {vid_policy}"
+            writer.option("vidPolicy", vid_policy)
+            self._options["vidPolicy"] = vid_policy
+
+            # vertexField setting, by default, it's _id, must be a string
+            vertexField = kwargs.get("vid_field", "_id")
+            assert isinstance(
+                vertexField, str
+            ), f"vid_field should be a string, but got {type(vertexField)}"
+            writer.option("vertexField", vertexField)
+            self._options["vertexField"] = vertexField
+
+        if type == "edge":
+            # srcId setting, by default, it's srcId, must be a string
+            src_id = kwargs.get("src_id", "srcId")
+            assert isinstance(
+                src_id, str
+            ), f"src_id should be a string, but got {type(src_id)}"
+            writer.option("srcId", src_id)
+            self._options["srcId"] = src_id
+
+            # dstId setting, by default, it's dstId, must be a string
+            dst_id = kwargs.get("dst_id", "dstId")
+            assert isinstance(
+                dst_id, str
+            ), f"dst_id should be a string, but got {type(dst_id)}"
+            writer.option("dstId", dst_id)
+            self._options["dstId"] = dst_id
+
+            # srcIdPolicy setting, by default, it's empty, accept hash or uuid, too
+            src_id_policy = kwargs.get("src_id_policy", "")
+            assert src_id_policy in [
+                "",
+                "hash",
+                "uuid",
+            ], f"src_id_policy should be empty, hash or uuid, but got {src_id_policy}"
+            writer.option("srcIdPolicy", src_id_policy)
+            self._options["srcIdPolicy"] = src_id_policy
+
+            # dstIdPolicy setting, by default, it's empty, accept hash or uuid, too
+            dst_id_policy = kwargs.get("dst_id_policy", "")
+            assert dst_id_policy in [
+                "",
+                "hash",
+                "uuid",
+            ], f"dst_id_policy should be empty, hash or uuid, but got {dst_id_policy}"
+            writer.option("dstIdPolicy", dst_id_policy)
+            self._options["dstIdPolicy"] = dst_id_policy
+
+            # randkField setting, by default, it's empty, must be a string
+            rank_field = kwargs.get("rank_field", "")
+            assert isinstance(
+                rank_field, str
+            ), f"rank_field should be a string, but got {type(rank_field)}"
+            writer.option("rankField", rank_field)
+            self._options["rankField"] = rank_field
+
+    def _set_options_with_file(self, **kwargs):
+        raise NotImplementedError
+
+    def _set_options_with_server(self, **kwargs):
+        raise NotImplementedError
+
+    def set_options(self, **kwargs):
+        """
+        example:
+        # change col name
+        louvain_result_df = louvain_result.toDF()
+
+        # CREATE TAG IF NOT EXISTS louvain (
+        #     cluster_id string NOT NULL
+        # );
+
+        louvain_result_df = louvain_result_df.withColumnRenamed("louvain", "cluster_id")
+        louvain_result_df.write.format("com.vesoft.nebula.connector.NebulaDataSource").option(
+            "type", "vertex").option(
+            "spaceName", "basketballplayer").option(
+            "label", "louvain").option(
+            "vidPolicy", "").option(
+            "vertexField", "_id").option(
+            "batch", 1).option(
+            "metaAddress", "metad0:9559,metad1:9559,metad2:9559").option(
+            "graphAddress", "graphd:9669").option(
+            "passwd", "nebula").option(
+            "user", "root").option(
+            "writeType", "insert")
+        """
+        if self.raw_df is None:
+            if self.jdf is None:
+                raise ValueError("DataFrame is None in NebulaWriter")
+            self.raw_df = self._convert_java_object_to_spark_df(
+                self.jdf, kwargs.get("properties", {})
+            )
+        # TBD: check tag/edge type's schema against df's schema, raise error if not match
+
+        self._get_raw_df_writer()  # self.raw_df_writer
+
+        # case switch based on sink
+        if self.sink in SPARK_NEBULA_SINKS:
+            self._set_options_with_nebula(**kwargs)
+        elif self.sink in SPARK_FILE_SINKS:
+            self._set_options_with_file(**kwargs)
+        elif self.sink in SPARK_SERVER_SINKS:
+            self._set_options_with_server(**kwargs)
+        else:
+            raise NotImplementedError
+
+        return self._options
+
+    def get_options(self):
+        return self._options
+
+    def write(self):
+        # Check self.raw_df, if it is None, raise exception
+        if self.raw_df_writer is None:
+            raise Exception(
+                "No options set for NebulaWriter, please call options() first"
+            )
+        return self.raw_df_writer.save()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "ngdi"
-version = "0.1.8"
+version = "0.1.9"
 description = "NebulaGraph Data Intelligence Suite"
 authors = [
     {name = "Wey Gu", email = "weyl.gu@gmail.com"},


### PR DESCRIPTION
- API docs polished
- writer added
- 0.1.9 rc

close: #2 

## Doc

## NebulaWriter

`ngdi.NebulaWriter` writes the computed or queried data to different sinks.
Supported sinks include:
- NebulaGraph(Spark Engine, NebulaGraph Engine)
- CSV(Spark Engine, NebulaGraph Engine)
- S3(Spark Engine, NebulaGraph Engine), not yet implemented.

### Functions

- `ngdi.NebulaWriter.options()` sets the options for the sink.
- `ngdi.NebulaWriter.write()` writes the data to the sink.
- `ngdi.NebulaWriter.show_options()` shows the options for the sink.

### Examples

#### Spark Engine

- NebulaGraph sink

Assume that we have a Spark DataFrame `df_result` computed with `df.algo.louvain()` with the following schema:

```python
df_result.printSchema()
# result:
root
 |-- _id: string (nullable = false)
 |-- louvain: string (nullable = false)
```

We created a TAG `louvain` in NebulaGraph on same space with the following schema:

```ngql
CREATE TAG IF NOT EXISTS louvain (
    cluster_id string NOT NULL
);
```

Then, we could write the louvain result to NebulaGraph, map the column `louvain` to `cluster_id` with the following code:

```python
from ngdi import NebulaWriter
from ngdi.config import NebulaGraphConfig

config = NebulaGraphConfig()

properties = {
    "louvain": "cluster_id"
}

writer = NebulaWriter(data=df_result, sink="nebulagraph_vertex", config=config, engine="spark")
writer.set_options(
    tag="louvain",
    vid_field="_id",
    properties=properties,
    batch_size=256,
    write_mode="insert",
)
writer.write()
```

Then we could query the result in NebulaGraph:

```cypher
MATCH (v:louvain)
RETURN id(v), v.louvain.cluster_id LIMIT 10;
```